### PR TITLE
Update nginx Dockerfile to track mainline instead of 1.21

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.21-alpine
+FROM nginx:mainline-alpine
 
 RUN rm /etc/nginx/conf.d/default.conf
 COPY nginx.conf /etc/nginx/conf.d


### PR DESCRIPTION
- 1.21 is no longer supported: https://hub.docker.com/_/nginx
- nginx recommends mainline for most people: https://www.nginx.com/blog/nginx-1-16-1-17-released/